### PR TITLE
WIP: Reimport sources after glyphsLib update

### DIFF
--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -130,7 +130,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -231,9 +233,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -231,9 +231,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -132,346 +132,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -487,8 +522,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -509,6 +560,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -519,18 +571,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -545,271 +720,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -828,8 +770,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -842,14 +804,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1378,14 +1349,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1438,6 +1419,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1466,6 +1451,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1484,8 +1471,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1506,8 +1501,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1538,6 +1537,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -221,9 +221,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -120,7 +120,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -221,9 +223,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -129,346 +129,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -484,8 +519,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -506,6 +557,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -516,18 +568,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -542,271 +717,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -825,8 +767,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -839,14 +801,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1375,14 +1346,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1435,6 +1416,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1463,6 +1448,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1481,8 +1468,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1503,8 +1498,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1535,6 +1534,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -221,9 +221,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -120,7 +120,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -221,9 +223,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -221,9 +221,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -120,7 +120,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -221,9 +223,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -130,7 +130,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -231,9 +233,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -231,9 +231,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -221,9 +221,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -120,7 +120,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -221,9 +223,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -221,9 +221,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -120,7 +120,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -221,9 +223,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -221,9 +221,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -120,7 +120,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -221,9 +223,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -139,9 +139,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -38,7 +38,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -139,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -106,7 +106,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -207,9 +209,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -207,9 +207,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -139,9 +139,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -38,7 +38,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -139,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -102,7 +102,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -203,9 +205,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -203,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -139,9 +139,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -38,7 +38,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -139,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -106,7 +106,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -207,9 +209,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -207,9 +207,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -106,7 +106,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -207,9 +209,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -207,9 +207,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -161,9 +161,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -60,7 +60,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -161,9 +163,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -133,346 +133,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -488,8 +523,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -510,6 +561,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -520,18 +572,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -546,271 +721,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -829,8 +771,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -843,14 +805,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1379,14 +1350,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1439,6 +1420,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1467,6 +1452,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1485,8 +1472,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1507,8 +1502,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1539,6 +1538,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -161,9 +161,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -60,7 +60,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -161,9 +163,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -161,9 +161,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -60,7 +60,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -161,9 +163,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -161,9 +161,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -60,7 +60,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -161,9 +163,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -132,346 +132,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -487,8 +522,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -509,6 +560,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -519,18 +571,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -545,271 +720,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -828,8 +770,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -842,14 +804,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1378,14 +1349,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1438,6 +1419,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1466,6 +1451,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1484,8 +1471,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1506,8 +1501,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1538,6 +1537,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -129,346 +129,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -484,8 +519,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -506,6 +557,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -516,18 +568,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -542,271 +717,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -825,8 +767,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -839,14 +801,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1375,14 +1346,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1435,6 +1416,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1463,6 +1448,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1481,8 +1468,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1503,8 +1498,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1535,6 +1534,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -196,7 +196,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -297,9 +299,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -297,9 +297,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -196,7 +196,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -297,9 +299,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -297,9 +297,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -182,7 +182,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -283,9 +285,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -283,9 +283,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -132,346 +132,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -487,8 +522,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -509,6 +560,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -519,18 +571,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -545,271 +720,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -828,8 +770,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -842,14 +804,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1378,14 +1349,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1438,6 +1419,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1466,6 +1451,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1484,8 +1471,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1506,8 +1501,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1538,6 +1537,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -275,9 +275,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -174,7 +174,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -275,9 +277,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -129,346 +129,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -484,8 +519,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -506,6 +557,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -516,18 +568,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -542,271 +717,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -825,8 +767,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -839,14 +801,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1375,14 +1346,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1435,6 +1416,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1463,6 +1448,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1481,8 +1468,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1503,8 +1498,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1535,6 +1534,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -182,7 +182,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -283,9 +285,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -283,9 +283,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -182,7 +182,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -283,9 +285,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -283,9 +283,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -182,7 +182,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -283,9 +285,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -283,9 +283,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -161,9 +161,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -60,7 +60,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -161,9 +163,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -182,7 +182,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -283,9 +285,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -283,9 +283,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -192,7 +192,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -293,9 +295,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -293,9 +293,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -147,9 +147,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -46,7 +46,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -147,9 +149,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -147,9 +147,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -46,7 +46,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -147,9 +149,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -147,9 +147,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -46,7 +46,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -147,9 +149,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -147,9 +147,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -46,7 +46,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -147,9 +149,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -159,9 +159,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -58,7 +58,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -159,9 +161,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -151,9 +151,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -50,7 +50,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -151,9 +153,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -159,9 +159,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -58,7 +58,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -159,9 +161,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -151,9 +151,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -50,7 +50,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -151,9 +153,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -249,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -148,7 +148,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -249,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -132,346 +132,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -487,8 +522,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -509,6 +560,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -519,18 +571,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -545,271 +720,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -828,8 +770,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -842,14 +804,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1378,14 +1349,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1438,6 +1419,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1466,6 +1451,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1484,8 +1471,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1506,8 +1501,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1538,6 +1537,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -140,7 +140,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -241,9 +243,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -241,9 +241,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -129,346 +129,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -484,8 +519,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -506,6 +557,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -516,18 +568,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -542,271 +717,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -825,8 +767,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -839,14 +801,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1375,14 +1346,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1435,6 +1416,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1463,6 +1448,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1481,8 +1468,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1503,8 +1498,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1535,6 +1534,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -249,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -148,7 +148,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -249,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -140,7 +140,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -241,9 +243,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -241,9 +241,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -249,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -148,7 +148,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -249,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -249,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -148,7 +148,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -249,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -249,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -148,7 +148,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -249,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -249,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -148,7 +148,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -249,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -156,7 +156,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -257,9 +259,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -257,9 +257,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -149,346 +149,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -504,8 +539,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -526,6 +577,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -536,18 +588,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -562,271 +737,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -845,8 +787,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -859,14 +821,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1395,14 +1366,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1455,6 +1436,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1483,6 +1468,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1501,8 +1488,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1523,8 +1518,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1555,6 +1554,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -108,7 +108,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -209,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -209,9 +209,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -108,7 +108,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -209,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -209,9 +209,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -156,7 +156,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -257,9 +259,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -257,9 +257,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -108,7 +108,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -209,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -209,9 +209,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -133,346 +133,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -488,8 +523,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -510,6 +561,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -520,18 +572,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -546,271 +721,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -829,8 +771,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -843,14 +805,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1379,14 +1350,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1439,6 +1420,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1467,6 +1452,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1485,8 +1472,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1507,8 +1502,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1539,6 +1538,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -142,346 +142,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -497,8 +532,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -519,6 +570,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -529,18 +581,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -555,271 +730,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -838,8 +780,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -852,14 +814,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1388,14 +1359,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1448,6 +1429,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1476,6 +1461,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1494,8 +1481,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1516,8 +1511,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1548,6 +1547,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -251,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -150,7 +150,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -251,9 +253,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -239,9 +239,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -138,7 +138,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -239,9 +241,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -149,346 +149,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -504,8 +539,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -526,6 +577,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -536,18 +588,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -562,271 +737,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -845,8 +787,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -859,14 +821,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1395,14 +1366,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1455,6 +1436,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1483,6 +1468,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1501,8 +1488,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1523,8 +1518,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1555,6 +1554,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -247,9 +247,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -146,7 +146,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -247,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -239,9 +239,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -138,7 +138,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -239,9 +241,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -251,9 +251,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -150,7 +150,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -251,9 +253,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -239,9 +239,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -138,7 +138,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -239,9 +241,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -247,9 +247,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -146,7 +146,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -247,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -239,9 +239,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -138,7 +138,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -239,9 +241,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -217,9 +217,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -116,7 +116,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -217,9 +219,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -188,7 +188,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -289,9 +291,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -289,9 +289,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -188,7 +188,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -289,9 +291,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -289,9 +289,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -217,9 +217,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -116,7 +116,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -217,9 +219,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -188,7 +188,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -289,9 +291,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -289,9 +289,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -188,7 +188,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -289,9 +291,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -289,9 +289,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -132,346 +132,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -487,8 +522,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -509,6 +560,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -519,18 +571,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -545,271 +720,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -828,8 +770,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -842,14 +804,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1378,14 +1349,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1438,6 +1419,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1466,6 +1451,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1484,8 +1471,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1506,8 +1501,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1538,6 +1537,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -129,346 +129,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -484,8 +519,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -506,6 +557,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -516,18 +568,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -542,271 +717,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -825,8 +767,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -839,14 +801,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1375,14 +1346,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1435,6 +1416,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1463,6 +1448,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1481,8 +1468,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1503,8 +1498,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1535,6 +1534,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -190,7 +190,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -291,9 +293,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -291,9 +291,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -190,7 +190,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -291,9 +293,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -291,9 +291,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -169,9 +169,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -68,7 +68,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -169,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -169,9 +169,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -68,7 +68,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -169,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -169,9 +169,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -68,7 +68,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -169,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -169,9 +169,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -68,7 +68,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -169,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -269,9 +269,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -168,7 +168,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -269,9 +271,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -132,346 +132,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -487,8 +522,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -509,6 +560,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -519,18 +571,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -545,271 +720,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -828,8 +770,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -842,14 +804,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1378,14 +1349,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1438,6 +1419,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1466,6 +1451,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1484,8 +1471,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1506,8 +1501,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1538,6 +1537,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -259,9 +259,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -158,7 +158,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -259,9 +261,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -129,346 +129,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -484,8 +519,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -506,6 +557,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -516,18 +568,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -542,271 +717,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -825,8 +767,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -839,14 +801,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1375,14 +1346,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1435,6 +1416,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1463,6 +1448,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1481,8 +1468,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1503,8 +1498,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1535,6 +1534,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -269,9 +269,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -168,7 +168,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -269,9 +271,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -259,9 +259,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -158,7 +158,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -259,9 +261,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -269,9 +269,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -168,7 +168,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -269,9 +271,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -259,9 +259,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -158,7 +158,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -259,9 +261,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -170,7 +170,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -271,9 +273,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -271,9 +271,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -259,9 +259,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -158,7 +158,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -259,9 +261,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -146,7 +146,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -247,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -247,9 +247,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -195,9 +195,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -94,7 +94,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -195,9 +197,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -195,9 +195,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -94,7 +94,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -195,9 +197,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -146,7 +146,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -247,9 +249,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -247,9 +247,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -195,9 +195,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -94,7 +94,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -195,9 +197,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -141,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -40,7 +40,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -141,9 +143,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -141,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -40,7 +40,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -141,9 +143,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -141,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -40,7 +40,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -141,9 +143,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -141,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -40,7 +40,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -141,9 +143,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>100</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -132,346 +132,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -487,8 +522,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -509,6 +560,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -519,18 +571,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -545,271 +720,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -828,8 +770,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -842,14 +804,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1378,14 +1349,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1438,6 +1419,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1466,6 +1451,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1484,8 +1471,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1506,8 +1501,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1538,6 +1537,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -287,9 +287,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -186,7 +186,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -287,9 +289,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -129,346 +129,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -484,8 +519,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -506,6 +557,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -516,18 +568,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -542,271 +717,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -825,8 +767,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -839,14 +801,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1375,14 +1346,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1435,6 +1416,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1463,6 +1448,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1481,8 +1468,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1503,8 +1498,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1535,6 +1534,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -201,9 +201,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -100,7 +100,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -201,9 +203,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -176,7 +176,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -277,9 +279,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -277,9 +277,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -116,346 +116,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -471,8 +506,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -493,6 +544,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -503,18 +555,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -529,271 +704,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -812,8 +754,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -826,14 +788,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1362,14 +1333,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1422,6 +1403,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1450,6 +1435,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1468,8 +1455,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1490,8 +1485,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1522,6 +1521,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -110,7 +110,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -211,9 +213,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -211,9 +211,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -279,9 +279,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -178,7 +178,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -279,9 +281,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -287,9 +287,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -186,7 +186,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -287,9 +289,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -133,346 +133,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -488,8 +523,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -510,6 +561,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -520,18 +572,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -546,271 +721,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -829,8 +771,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -843,14 +805,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1379,14 +1350,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1439,6 +1420,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1467,6 +1452,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1485,8 +1472,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1507,8 +1502,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1539,6 +1538,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -90,7 +90,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -191,9 +193,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -191,9 +191,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -90,7 +90,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -191,9 +193,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -191,9 +191,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -287,9 +287,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -186,7 +186,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -287,9 +289,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -194,7 +194,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -295,9 +297,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -295,9 +295,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -90,7 +90,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -191,9 +193,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -191,9 +191,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -142,346 +142,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -497,8 +532,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -519,6 +570,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -529,18 +581,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -555,271 +730,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -838,8 +780,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -852,14 +814,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1388,14 +1359,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1448,6 +1429,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1476,6 +1461,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1494,8 +1481,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1516,8 +1511,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1548,6 +1547,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -90,7 +90,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -191,9 +193,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -191,9 +191,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -122,346 +122,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -477,8 +512,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -499,6 +550,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -509,18 +561,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -535,271 +710,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -818,8 +760,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -832,14 +794,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1368,14 +1339,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1428,6 +1409,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1456,6 +1441,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1474,8 +1461,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1496,8 +1491,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1528,6 +1527,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -70,7 +70,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -171,9 +173,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -171,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -133,346 +133,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -488,8 +523,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -510,6 +561,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -520,18 +572,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -546,271 +721,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -829,8 +771,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -843,14 +805,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1379,14 +1350,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1439,6 +1420,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1467,6 +1452,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1485,8 +1472,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1507,8 +1502,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1539,6 +1538,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -70,7 +70,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -171,9 +173,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -171,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -70,7 +70,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -171,9 +173,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -171,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -142,346 +142,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -497,8 +532,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -519,6 +570,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -529,18 +581,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -555,271 +730,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -838,8 +780,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -852,14 +814,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1388,14 +1359,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1448,6 +1429,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1476,6 +1461,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1494,8 +1481,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1516,8 +1511,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1548,6 +1547,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -70,7 +70,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -171,9 +173,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -171,9 +171,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -122,346 +122,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>151</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -477,8 +512,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -499,6 +550,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -509,18 +561,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -535,271 +710,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -818,8 +760,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -832,14 +794,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1368,14 +1339,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1428,6 +1409,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1456,6 +1441,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1474,8 +1461,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1496,8 +1491,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1528,6 +1527,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -196,7 +196,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -297,9 +299,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -297,9 +297,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -160,7 +160,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -261,9 +263,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -261,9 +261,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -160,7 +160,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -261,9 +263,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -261,9 +261,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -196,7 +196,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -297,9 +299,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -297,9 +297,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -196,7 +196,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -297,9 +299,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -297,9 +297,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -206,7 +206,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -307,9 +309,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -307,9 +307,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -160,7 +160,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -261,9 +263,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -261,9 +261,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -166,7 +166,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -267,9 +269,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -267,9 +267,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/lib.plist
@@ -149,346 +149,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -504,8 +539,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -526,6 +577,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -536,18 +588,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -562,271 +737,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -845,8 +787,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -859,14 +821,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1395,14 +1366,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1455,6 +1436,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1483,6 +1468,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1501,8 +1488,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1523,8 +1518,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1555,6 +1554,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -139,9 +139,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -38,7 +38,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -139,9 +141,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -162,7 +162,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -263,9 +265,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -263,9 +263,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/lib.plist
@@ -136,346 +136,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -491,8 +526,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -513,6 +564,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -523,18 +575,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -549,271 +724,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -832,8 +774,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -846,14 +808,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1382,14 +1353,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1442,6 +1423,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1470,6 +1455,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1488,8 +1475,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1510,8 +1505,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1542,6 +1541,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/lib.plist
@@ -134,346 +134,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -489,8 +524,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -511,6 +562,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -521,18 +573,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -547,271 +722,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -830,8 +772,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -844,14 +806,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1380,14 +1351,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1440,6 +1421,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1468,6 +1453,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1486,8 +1473,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1508,8 +1503,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1540,6 +1539,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/lib.plist
@@ -131,346 +131,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -486,8 +521,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -508,6 +559,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -518,18 +570,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -544,271 +719,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -827,8 +769,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -841,14 +803,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1377,14 +1348,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1437,6 +1418,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1465,6 +1450,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1483,8 +1470,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1505,8 +1500,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1537,6 +1536,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/lib.plist
@@ -138,346 +138,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -493,8 +528,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -515,6 +566,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -525,18 +577,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -551,271 +726,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -834,8 +776,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -848,14 +810,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1384,14 +1355,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1444,6 +1425,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1472,6 +1457,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1490,8 +1477,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1512,8 +1507,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1544,6 +1543,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/lib.plist
@@ -118,346 +118,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -473,8 +508,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -495,6 +546,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -505,18 +557,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -531,271 +706,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -814,8 +756,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -828,14 +790,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1364,14 +1335,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1424,6 +1405,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1452,6 +1437,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1470,8 +1457,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1492,8 +1487,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1524,6 +1523,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/lib.plist
@@ -140,346 +140,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -495,8 +530,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -517,6 +568,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -527,18 +579,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -553,271 +728,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -836,8 +778,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -850,14 +812,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1386,14 +1357,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1446,6 +1427,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1474,6 +1459,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1492,8 +1479,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1514,8 +1509,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1546,6 +1545,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -27,7 +27,9 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://design.google</string>
     <key>openTypeNameLicense</key>
-    <string>Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
@@ -128,9 +130,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>2</integer>
+    <integer>3</integer>
     <key>versionMinor</key>
-    <integer>0</integer>
+    <integer>7</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -128,9 +128,9 @@
     <key>unitsPerEm</key>
     <integer>2000</integer>
     <key>versionMajor</key>
-    <integer>3</integer>
+    <integer>2</integer>
     <key>versionMinor</key>
-    <integer>6</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/lib.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/lib.plist
@@ -120,346 +120,381 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
     <integer>25</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
-      <string>uni000D</string>
-      <string>space</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>currency</string>
-      <string>dollar</string>
-      <string>Euro</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Abreveacute</string>
+      <string>Abrevedotbelow</string>
+      <string>Abrevegrave</string>
+      <string>Abrevehookabove</string>
+      <string>Abrevetilde</string>
+      <string>Acaron</string>
+      <string>Acircumflex</string>
+      <string>Acircumflexacute</string>
+      <string>Acircumflexdotbelow</string>
+      <string>Acircumflexgrave</string>
+      <string>Acircumflexhookabove</string>
+      <string>Acircumflextilde</string>
+      <string>Adieresis</string>
+      <string>Adotbelow</string>
+      <string>Agrave</string>
+      <string>Ahookabove</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Atilde</string>
+      <string>AE</string>
       <string>B</string>
+      <string>Bhook</string>
       <string>C</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Cdotaccent</string>
       <string>D</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Dhook</string>
+      <string>Eth</string>
       <string>E</string>
+      <string>Eacute</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Ecircumflexacute</string>
+      <string>Ecircumflexdotbelow</string>
+      <string>Ecircumflexgrave</string>
+      <string>Ecircumflexhookabove</string>
+      <string>Ecircumflextilde</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Edotbelow</string>
+      <string>Egrave</string>
+      <string>Ehookabove</string>
+      <string>Emacron</string>
+      <string>Eogonek</string>
+      <string>Etilde</string>
+      <string>Schwa</string>
       <string>F</string>
       <string>G</string>
+      <string>Gbreve</string>
+      <string>Gcommaaccent</string>
+      <string>Gdotaccent</string>
       <string>H</string>
+      <string>Hbar</string>
       <string>I</string>
-      <string>J</string>
-      <string>K</string>
-      <string>L</string>
-      <string>M</string>
-      <string>N</string>
-      <string>O</string>
-      <string>P</string>
-      <string>Q</string>
-      <string>R</string>
-      <string>S</string>
-      <string>T</string>
-      <string>U</string>
-      <string>V</string>
-      <string>W</string>
-      <string>X</string>
-      <string>Y</string>
-      <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>nbspace</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemetleft</string>
-      <string>logicalnot</string>
-      <string>softhyphen</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>acute</string>
-      <string>micro</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
-      <string>ordmasculine</string>
-      <string>guillemetright</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
-      <string>questiondown</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
+      <string>IJ</string>
       <string>Iacute</string>
       <string>Icircumflex</string>
       <string>Idieresis</string>
-      <string>Eth</string>
+      <string>Idotaccent</string>
+      <string>Idotbelow</string>
+      <string>Igrave</string>
+      <string>Ihookabove</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>J</string>
+      <string>K</string>
+      <string>Kcommaaccent</string>
+      <string>Khook</string>
+      <string>L</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>M</string>
+      <string>N</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ndotaccent</string>
       <string>Ntilde</string>
-      <string>Ograve</string>
+      <string>O</string>
       <string>Oacute</string>
       <string>Ocircumflex</string>
-      <string>Otilde</string>
+      <string>Ocircumflexacute</string>
+      <string>Ocircumflexdotbelow</string>
+      <string>Ocircumflexgrave</string>
+      <string>Ocircumflexhookabove</string>
+      <string>Ocircumflextilde</string>
       <string>Odieresis</string>
-      <string>multiply</string>
+      <string>Odotbelow</string>
+      <string>Ograve</string>
+      <string>Ohookabove</string>
+      <string>Ohorn</string>
+      <string>Ohornacute</string>
+      <string>Ohorndotbelow</string>
+      <string>Ohorngrave</string>
+      <string>Ohornhookabove</string>
+      <string>Ohorntilde</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
       <string>Oslash</string>
-      <string>Ugrave</string>
+      <string>Otilde</string>
+      <string>OE</string>
+      <string>P</string>
+      <string>Thorn</string>
+      <string>Q</string>
+      <string>R</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>S</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scommaaccent</string>
+      <string>Sdotbelow</string>
+      <string>Germandbls</string>
+      <string>T</string>
+      <string>Tcaron</string>
+      <string>Tcedilla</string>
+      <string>Tcommaaccent</string>
+      <string>U</string>
       <string>Uacute</string>
+      <string>Ubreve</string>
       <string>Ucircumflex</string>
       <string>Udieresis</string>
+      <string>Udotbelow</string>
+      <string>Ugrave</string>
+      <string>Uhookabove</string>
+      <string>Uhorn</string>
+      <string>Uhornacute</string>
+      <string>Uhorndotbelow</string>
+      <string>Uhorngrave</string>
+      <string>Uhornhookabove</string>
+      <string>Uhorntilde</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>V</string>
+      <string>W</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>X</string>
+      <string>Y</string>
       <string>Yacute</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
-      <string>agrave</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ydotbelow</string>
+      <string>Ygrave</string>
+      <string>Yhook</string>
+      <string>Yhookabove</string>
+      <string>Ytilde</string>
+      <string>Z</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>G.super</string>
+      <string>a</string>
       <string>aacute</string>
+      <string>abreve</string>
+      <string>abreveacute</string>
+      <string>abrevedotbelow</string>
+      <string>abrevegrave</string>
+      <string>abrevehookabove</string>
+      <string>abrevetilde</string>
+      <string>acaron</string>
       <string>acircumflex</string>
-      <string>atilde</string>
+      <string>acircumflexacute</string>
+      <string>acircumflexdotbelow</string>
+      <string>acircumflexgrave</string>
+      <string>acircumflexhookabove</string>
+      <string>acircumflextilde</string>
       <string>adieresis</string>
+      <string>adotbelow</string>
+      <string>agrave</string>
+      <string>ahookabove</string>
+      <string>amacron</string>
+      <string>aogonek</string>
       <string>aring</string>
+      <string>atilde</string>
       <string>ae</string>
+      <string>b</string>
+      <string>bhook</string>
+      <string>c</string>
+      <string>cacute</string>
+      <string>ccaron</string>
       <string>ccedilla</string>
-      <string>egrave</string>
+      <string>cdotaccent</string>
+      <string>d</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>dhook</string>
+      <string>eth</string>
+      <string>e</string>
       <string>eacute</string>
+      <string>ecaron</string>
       <string>ecircumflex</string>
+      <string>ecircumflexacute</string>
+      <string>ecircumflexdotbelow</string>
+      <string>ecircumflexgrave</string>
+      <string>ecircumflexhookabove</string>
+      <string>ecircumflextilde</string>
       <string>edieresis</string>
-      <string>igrave</string>
+      <string>edotaccent</string>
+      <string>edotbelow</string>
+      <string>egrave</string>
+      <string>ehookabove</string>
+      <string>emacron</string>
+      <string>eogonek</string>
+      <string>etilde</string>
+      <string>schwa</string>
+      <string>f</string>
+      <string>g</string>
+      <string>gbreve</string>
+      <string>gcommaaccent</string>
+      <string>gdotaccent</string>
+      <string>h</string>
+      <string>hbar</string>
+      <string>i</string>
+      <string>idotless</string>
       <string>iacute</string>
       <string>icircumflex</string>
       <string>idieresis</string>
-      <string>eth</string>
+      <string>idotbelow</string>
+      <string>igrave</string>
+      <string>ihookabove</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>ij</string>
+      <string>j</string>
+      <string>jdotless</string>
+      <string>k</string>
+      <string>kcommaaccent</string>
+      <string>khook</string>
+      <string>l</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>m</string>
+      <string>n</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ndotaccent</string>
       <string>ntilde</string>
-      <string>ograve</string>
+      <string>o</string>
       <string>oacute</string>
       <string>ocircumflex</string>
-      <string>otilde</string>
+      <string>ocircumflexacute</string>
+      <string>ocircumflexdotbelow</string>
+      <string>ocircumflexgrave</string>
+      <string>ocircumflexhookabove</string>
+      <string>ocircumflextilde</string>
       <string>odieresis</string>
-      <string>divide</string>
+      <string>odotbelow</string>
+      <string>ograve</string>
+      <string>ohookabove</string>
+      <string>ohorn</string>
+      <string>ohornacute</string>
+      <string>ohorndotbelow</string>
+      <string>ohorngrave</string>
+      <string>ohornhookabove</string>
+      <string>ohorntilde</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
       <string>oslash</string>
-      <string>ugrave</string>
+      <string>otilde</string>
+      <string>oe</string>
+      <string>p</string>
+      <string>thorn</string>
+      <string>q</string>
+      <string>r</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>s</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scommaaccent</string>
+      <string>sdotbelow</string>
+      <string>germandbls</string>
+      <string>t</string>
+      <string>tcaron</string>
+      <string>tcedilla</string>
+      <string>tcommaaccent</string>
+      <string>u</string>
       <string>uacute</string>
+      <string>ubreve</string>
       <string>ucircumflex</string>
       <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>idotless</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
-      <string>gravecomb</string>
-      <string>acutecomb</string>
-      <string>circumflexcomb</string>
-      <string>tildecomb</string>
-      <string>macroncomb</string>
-      <string>brevecomb</string>
-      <string>dotaccentcomb</string>
-      <string>dieresiscomb</string>
-      <string>ringcomb</string>
-      <string>hungarumlautcomb</string>
-      <string>caroncomb</string>
-      <string>cedillacomb</string>
-      <string>ogonekcomb</string>
-      <string>mu</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
-      <string>foursuperior</string>
-      <string>f_i</string>
-      <string>f_l</string>
-      <string>Germandbls</string>
-      <string>OE</string>
-      <string>oe</string>
-      <string>commaaccentcomb</string>
-      <string>commaturnedabovecomb</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Scaron</string>
-      <string>scaron</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>IJ</string>
-      <string>ij</string>
-      <string>jdotless</string>
-      <string>Ydieresis</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Uhungarumlaut</string>
+      <string>udotbelow</string>
+      <string>ugrave</string>
+      <string>uhookabove</string>
+      <string>uhorn</string>
+      <string>uhornacute</string>
+      <string>uhorndotbelow</string>
+      <string>uhorngrave</string>
+      <string>uhornhookabove</string>
+      <string>uhorntilde</string>
       <string>uhungarumlaut</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Umacron</string>
       <string>umacron</string>
-      <string>Uogonek</string>
       <string>uogonek</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Scommaaccent</string>
-      <string>scommaaccent</string>
-      <string>Tcommaaccent</string>
-      <string>tcommaaccent</string>
-      <string>Tcedilla</string>
-      <string>tcedilla</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>v</string>
+      <string>w</string>
       <string>wacute</string>
-      <string>Wdieresis</string>
+      <string>wcircumflex</string>
       <string>wdieresis</string>
-      <string>Ycircumflex</string>
+      <string>wgrave</string>
+      <string>x</string>
+      <string>y</string>
+      <string>yacute</string>
       <string>ycircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
-      <string>Idotaccent</string>
-      <string>Dcroat</string>
-      <string>dcroat</string>
-      <string>greaterequal</string>
-      <string>lessequal</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>G.logo</string>
-      <string>e.logo</string>
-      <string>g.logo</string>
-      <string>l.logo</string>
-      <string>o.logo</string>
-      <string>Google.logo</string>
-      <string>G.super</string>
-      <string>Gsuper</string>
+      <string>ydieresis</string>
+      <string>ydotbelow</string>
+      <string>ygrave</string>
+      <string>yhook</string>
+      <string>yhookabove</string>
+      <string>ytilde</string>
+      <string>z</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>a.alt</string>
+      <string>aacute.alt</string>
+      <string>abreve.alt</string>
+      <string>abreveacute.alt</string>
+      <string>abrevedotbelow.alt</string>
+      <string>abrevegrave.alt</string>
+      <string>abrevehookabove.alt</string>
+      <string>abrevetilde.alt</string>
+      <string>acaron.alt</string>
+      <string>acircumflex.alt</string>
+      <string>acircumflexacute.alt</string>
+      <string>acircumflexdotbelow.alt</string>
+      <string>acircumflexgrave.alt</string>
+      <string>acircumflexhookabove.alt</string>
+      <string>acircumflextilde.alt</string>
+      <string>adieresis.alt</string>
+      <string>adotbelow.alt</string>
+      <string>agrave.alt</string>
+      <string>ahookabove.alt</string>
+      <string>amacron.alt</string>
+      <string>aogonek.alt</string>
+      <string>aring.alt</string>
+      <string>atilde.alt</string>
+      <string>ae.alt</string>
+      <string>g.alt</string>
+      <string>gbreve.alt</string>
+      <string>gcommaaccent.alt</string>
+      <string>gdotaccent.alt</string>
+      <string>g.ss03</string>
+      <string>gbreve.ss03</string>
+      <string>gcommaaccent.ss03</string>
+      <string>gdotaccent.ss03</string>
+      <string>dcroat_comp</string>
       <string>f_b</string>
       <string>f_f</string>
       <string>f_f_b</string>
@@ -475,8 +510,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>f_k</string>
       <string>f_l</string>
       <string>f_t</string>
+      <string>hbar_comp</string>
       <string>t_f</string>
       <string>t_t</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>xsuperior</string>
+      <string>mu</string>
+      <string>u1D6E1</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
       <string>zero.denominator</string>
       <string>one.denominator</string>
       <string>two.denominator</string>
@@ -497,6 +548,7 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.numerator</string>
       <string>eight.numerator</string>
       <string>nine.numerator</string>
+      <string>zero.slash</string>
       <string>zero.tf</string>
       <string>one.tf</string>
       <string>two.tf</string>
@@ -507,18 +559,141 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>seven.tf</string>
       <string>eight.tf</string>
       <string>nine.tf</string>
+      <string>fraction</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
+      <string>zero.dnom.percent</string>
+      <string>zero.numr.percent</string>
+      <string>zerosubscript</string>
+      <string>onesubscript</string>
+      <string>twosubscript</string>
+      <string>threesubscript</string>
+      <string>foursubscript</string>
+      <string>fivesubscript</string>
+      <string>sixsubscript</string>
+      <string>sevensubscript</string>
+      <string>eightsubscript</string>
+      <string>ninesubscript</string>
+      <string>zerosuperscript</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>foursuperior</string>
+      <string>fivesuperscript</string>
+      <string>sixsuperscript</string>
+      <string>sevensuperscript</string>
+      <string>eightsuperscript</string>
+      <string>ninesuperscript</string>
+      <string>zero.sinf</string>
+      <string>one.sinf</string>
+      <string>two.sinf</string>
+      <string>three.sinf</string>
+      <string>four.sinf</string>
+      <string>five.sinf</string>
+      <string>six.sinf</string>
+      <string>seven.sinf</string>
+      <string>eight.sinf</string>
+      <string>nine.sinf</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>enspace</string>
+      <string>emspace</string>
+      <string>threeperemspace</string>
+      <string>fourperemspace</string>
+      <string>sixperemspace</string>
+      <string>thinspace</string>
+      <string>hairspace</string>
+      <string>zerowidthspace</string>
+      <string>narrownbspace</string>
+      <string>.notdef</string>
+      <string>uni000D</string>
+      <string>space.tf</string>
+      <string>hyphen</string>
+      <string>softhyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>underscore</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>guillemetleft</string>
+      <string>guillemetright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>quotedbl</string>
+      <string>quotesingle</string>
+      <string>period</string>
+      <string>comma</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>horizontalelipsis</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>periodcentered.loclCAT</string>
       <string>period.tf</string>
       <string>comma.tf</string>
       <string>colon.tf</string>
       <string>semicolon.tf</string>
       <string>numbersign.tf</string>
       <string>colon.time</string>
-      <string>space.tf</string>
+      <string>periodcentered.loclCAT.case</string>
+      <string>baht</string>
+      <string>baht.tf</string>
+      <string>baht.tf.001</string>
+      <string>Euro</string>
+      <string>cent</string>
+      <string>currency</string>
+      <string>dollar</string>
+      <string>rupeeIndian</string>
+      <string>sterling</string>
+      <string>won</string>
+      <string>yen</string>
       <string>cent.tf</string>
       <string>currency.tf</string>
       <string>dollar.tf</string>
       <string>Euro.tf</string>
+      <string>rupeeIndian.tf</string>
       <string>sterling.tf</string>
+      <string>won.tf</string>
+      <string>yen.tf</string>
+      <string>rupeeIndian.tf.001</string>
+      <string>minussuperior</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>greater</string>
+      <string>less</string>
+      <string>greaterequal</string>
+      <string>lessequal</string>
+      <string>plusminus</string>
+      <string>approxequal</string>
+      <string>asciitilde</string>
+      <string>logicalnot</string>
+      <string>asciicircum</string>
+      <string>radical</string>
+      <string>micro</string>
+      <string>percent</string>
       <string>plus.tf</string>
       <string>minus.tf</string>
       <string>multiply.tf</string>
@@ -533,271 +708,38 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>approxequal.tf</string>
       <string>logicalnot.tf</string>
       <string>percent.tf</string>
-      <string>section.tf</string>
-      <string>a.alt</string>
-      <string>aacute.alt</string>
-      <string>abreve.alt</string>
-      <string>acaron.alt</string>
-      <string>acircumflex.alt</string>
-      <string>adieresis.alt</string>
-      <string>agrave.alt</string>
-      <string>amacron.alt</string>
-      <string>aogonek.alt</string>
-      <string>aring.alt</string>
-      <string>atilde.alt</string>
-      <string>ae.alt</string>
-      <string>g.alt</string>
-      <string>gbreve.alt</string>
-      <string>gcommaaccent.alt</string>
-      <string>gdotaccent.alt</string>
-      <string>caroncomb.alt</string>
-      <string>zero.slash</string>
-      <string>zeroslash</string>
-      <string>zeroslash.tf</string>
-      <string>wiggle.medium</string>
-      <string>quoteright</string>
-      <string>quoteleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>bullet</string>
-      <string>endash</string>
-      <string>emdash</string>
-      <string>minus</string>
-      <string>horizontalelipsis</string>
-      <string>trademark</string>
-      <string>emspace</string>
-      <string>enspace</string>
-      <string>thinspace</string>
-      <string>hairspace</string>
-      <string>figurespace</string>
-      <string>fourperemspace</string>
-      <string>sixperemspace</string>
-      <string>threeperemspace</string>
-      <string>zerowidthspace</string>
-      <string>acaron</string>
-      <string>Acaron</string>
-      <string>cdotaccent</string>
-      <string>Cdotaccent</string>
-      <string>gdotaccent</string>
-      <string>Gdotaccent</string>
-      <string>hbar</string>
-      <string>Hbar</string>
-      <string>omacron</string>
-      <string>Omacron</string>
-      <string>rcommaaccent</string>
-      <string>Rcommaaccent</string>
-      <string>ubreve</string>
-      <string>Ubreve</string>
-      <string>ygrave</string>
-      <string>Ygrave</string>
-      <string>zero.sinf</string>
-      <string>one.sinf</string>
-      <string>two.sinf</string>
-      <string>three.sinf</string>
-      <string>four.sinf</string>
-      <string>five.sinf</string>
-      <string>six.sinf</string>
-      <string>seven.sinf</string>
-      <string>eight.sinf</string>
-      <string>nine.sinf</string>
-      <string>zerosuperscript</string>
-      <string>onesuperscript</string>
-      <string>twosuperscript</string>
-      <string>threesuperscript</string>
-      <string>foursuperscript</string>
-      <string>fivesuperscript</string>
-      <string>sixsuperscript</string>
-      <string>sevensuperscript</string>
-      <string>eightsuperscript</string>
-      <string>ninesuperscript</string>
-      <string>zerosubscript</string>
-      <string>onesubscript</string>
-      <string>twosubscript</string>
-      <string>threesubscript</string>
-      <string>foursubscript</string>
-      <string>fivesubscript</string>
-      <string>sixsubscript</string>
-      <string>sevensubscript</string>
-      <string>eightsubscript</string>
-      <string>ninesubscript</string>
-      <string>radical</string>
-      <string>u1D6E1</string>
-      <string>flig2</string>
-      <string>flig1</string>
-      <string>tlig</string>
-      <string>gcircumflex.alt</string>
-      <string>zeropercent</string>
-      <string>percentbar</string>
-      <string>exclam-top</string>
-      <string>question-top</string>
-      <string>exclam-bottom</string>
-      <string>question-bottom</string>
-      <string>dot-composite</string>
-      <string>dot-composite-top</string>
-      <string>Eth-bar</string>
-      <string>Oslash-bar</string>
-      <string>oslash-bar</string>
-      <string>diagonalbarl</string>
-      <string>horizontalbarlc</string>
-      <string>H-bar</string>
-      <string>Engeng</string>
-      <string>notequal-slash</string>
-      <string>greaterequal-stroke</string>
-      <string>percentbar.tf</string>
-      <string>diagonalbarllc</string>
-      <string>diagonalbarl-lc</string>
-      <string>Abreveacute</string>
-      <string>Abrevedotbelow</string>
-      <string>Abrevegrave</string>
-      <string>Abrevehookabove</string>
-      <string>Abrevetilde</string>
-      <string>Acircumflexacute</string>
-      <string>Acircumflexdotbelow</string>
-      <string>Acircumflexgrave</string>
-      <string>Acircumflexhookabove</string>
-      <string>Acircumflextilde</string>
-      <string>Adotbelow</string>
-      <string>Ahookabove</string>
-      <string>Bhook</string>
-      <string>Dhook</string>
-      <string>Ecircumflexacute</string>
-      <string>Ecircumflexdotbelow</string>
-      <string>Ecircumflexgrave</string>
-      <string>Ecircumflexhookabove</string>
-      <string>Ecircumflextilde</string>
-      <string>Edotbelow</string>
-      <string>Ehookabove</string>
-      <string>Etilde</string>
-      <string>Schwa</string>
-      <string>Idotbelow</string>
-      <string>Ihookabove</string>
-      <string>Itilde</string>
-      <string>Khook</string>
-      <string>Ndotaccent</string>
-      <string>Ocircumflexacute</string>
-      <string>Ocircumflexdotbelow</string>
-      <string>Ocircumflexgrave</string>
-      <string>Ocircumflexhookabove</string>
-      <string>Ocircumflextilde</string>
-      <string>Odotbelow</string>
-      <string>Ohookabove</string>
-      <string>Ohorn</string>
-      <string>Ohornacute</string>
-      <string>Ohorndotbelow</string>
-      <string>Ohorngrave</string>
-      <string>Ohornhookabove</string>
-      <string>Ohorntilde</string>
-      <string>Sdotbelow</string>
-      <string>Udotbelow</string>
-      <string>Uhookabove</string>
-      <string>Uhorn</string>
-      <string>Uhornacute</string>
-      <string>Uhorndotbelow</string>
-      <string>Uhorngrave</string>
-      <string>Uhornhookabove</string>
-      <string>Uhorntilde</string>
-      <string>Utilde</string>
-      <string>Ydotbelow</string>
-      <string>Yhook</string>
-      <string>Yhookabove</string>
-      <string>Ytilde</string>
-      <string>abreveacute</string>
-      <string>abrevedotbelow</string>
-      <string>abrevegrave</string>
-      <string>abrevehookabove</string>
-      <string>abrevetilde</string>
-      <string>acircumflexacute</string>
-      <string>acircumflexdotbelow</string>
-      <string>acircumflexgrave</string>
-      <string>acircumflexhookabove</string>
-      <string>acircumflextilde</string>
-      <string>adotbelow</string>
-      <string>ahookabove</string>
-      <string>bhook</string>
-      <string>dhook</string>
-      <string>ecircumflexacute</string>
-      <string>ecircumflexdotbelow</string>
-      <string>ecircumflexgrave</string>
-      <string>ecircumflexhookabove</string>
-      <string>ecircumflextilde</string>
-      <string>edotbelow</string>
-      <string>ehookabove</string>
-      <string>etilde</string>
-      <string>schwa</string>
-      <string>idotbelow</string>
-      <string>ihookabove</string>
-      <string>itilde</string>
-      <string>khook</string>
-      <string>ndotaccent</string>
-      <string>ocircumflexacute</string>
-      <string>ocircumflexdotbelow</string>
-      <string>ocircumflexgrave</string>
-      <string>ocircumflexhookabove</string>
-      <string>ocircumflextilde</string>
-      <string>odotbelow</string>
-      <string>ohookabove</string>
-      <string>ohorn</string>
-      <string>ohornacute</string>
-      <string>ohorndotbelow</string>
-      <string>ohorngrave</string>
-      <string>ohornhookabove</string>
-      <string>ohorntilde</string>
-      <string>sdotbelow</string>
-      <string>udotbelow</string>
-      <string>uhookabove</string>
-      <string>uhorn</string>
-      <string>uhornacute</string>
-      <string>uhorndotbelow</string>
-      <string>uhorngrave</string>
-      <string>uhornhookabove</string>
-      <string>uhorntilde</string>
-      <string>utilde</string>
-      <string>ydotbelow</string>
-      <string>yhook</string>
-      <string>yhookabove</string>
-      <string>ytilde</string>
-      <string>abreveacute.alt</string>
-      <string>abrevedotbelow.alt</string>
-      <string>abrevegrave.alt</string>
-      <string>abrevehookabove.alt</string>
-      <string>abrevetilde.alt</string>
-      <string>acircumflexacute.alt</string>
-      <string>acircumflexdotbelow.alt</string>
-      <string>acircumflexgrave.alt</string>
-      <string>acircumflexhookabove.alt</string>
-      <string>acircumflextilde.alt</string>
-      <string>adotbelow.alt</string>
-      <string>ahookabove.alt</string>
-      <string>g.ss03</string>
-      <string>gbreve.ss03</string>
-      <string>gcommaaccent.ss03</string>
-      <string>gdotaccent.ss03</string>
-      <string>dcroat_comp</string>
-      <string>hbar_comp</string>
-      <string>xsuperior</string>
-      <string>zero.dnom.percent</string>
-      <string>zero.numr.percent</string>
-      <string>uni00A0</string>
-      <string>narrownbspace</string>
-      <string>periodcentered.loclCAT</string>
-      <string>periodcentered.loclCAT.case</string>
-      <string>baht</string>
-      <string>baht.tf</string>
-      <string>baht.tf.001</string>
-      <string>rupeeIndian</string>
-      <string>won</string>
-      <string>rupeeIndian.tf</string>
-      <string>won.tf</string>
-      <string>yen.tf</string>
-      <string>rupeeIndian.tf.001</string>
-      <string>minussuperior</string>
       <string>multiplysuperior</string>
       <string>uni25CC</string>
+      <string>at</string>
+      <string>ampersand</string>
+      <string>paragraph</string>
+      <string>section</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>section.tf</string>
+      <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
+      <string>gravecomb</string>
+      <string>acutecomb</string>
+      <string>hungarumlautcomb</string>
+      <string>caroncomb.alt</string>
+      <string>circumflexcomb</string>
+      <string>caroncomb</string>
+      <string>brevecomb</string>
+      <string>ringcomb</string>
+      <string>tildecomb</string>
+      <string>macroncomb</string>
       <string>hookabovecomb</string>
+      <string>commaturnedabovecomb</string>
       <string>horncomb</string>
       <string>dotbelowcomb</string>
+      <string>commaaccentcomb</string>
+      <string>cedillacomb</string>
+      <string>ogonekcomb</string>
       <string>strokeshortcomb</string>
       <string>slashshortcomb</string>
       <string>horncomb.case</string>
@@ -816,8 +758,28 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>brevecomb.viet.case</string>
       <string>tildecomb.viet.case</string>
       <string>hookabovecomb.viet.case</string>
+      <string>dieresis</string>
+      <string>dotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>hungarumlaut</string>
+      <string>circumflex</string>
+      <string>caron</string>
+      <string>breve</string>
+      <string>ring</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
       <string>apostrophemod</string>
       <string>uni02BB</string>
+      <string>G.logo</string>
+      <string>o.logo</string>
+      <string>g.logo</string>
+      <string>l.logo</string>
+      <string>e.logo</string>
+      <string>Gsuper</string>
+      <string>Google.logo</string>
       <string>_copyright-circle</string>
       <string>_dots-divide</string>
       <string>_copyright-C</string>
@@ -830,14 +792,23 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>crossbar_C4</string>
       <string>crossbar_L</string>
       <string>crossbar_R</string>
+      <string>foursuperscript</string>
+      <string>greaterequal-stroke</string>
       <string>hook-builder</string>
+      <string>notequal-slash</string>
+      <string>onesuperscript</string>
       <string>stem_f</string>
       <string>stem_f2</string>
       <string>stem_t</string>
+      <string>threesuperscript</string>
+      <string>twosuperscript</string>
+      <string>zeroslash</string>
       <string>_tail.Q</string>
       <string>hornO.comb</string>
       <string>horno.comb</string>
       <string>percentbar.tab</string>
+      <string>wiggle.medium</string>
+      <string>zeroslash.tf</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
@@ -1366,14 +1337,24 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EB9</string>
       <key>ehookabove</key>
       <string>uni1EBB</string>
+      <key>eightsubscript</key>
+      <string>uni2088</string>
+      <key>eightsuperscript</key>
+      <string>uni2078</string>
       <key>emspace</key>
       <string>uni2003</string>
       <key>enspace</key>
       <string>uni2002</string>
       <key>etilde</key>
       <string>uni1EBD</string>
+      <key>fivesubscript</key>
+      <string>uni2085</string>
+      <key>fivesuperscript</key>
+      <string>uni2075</string>
       <key>fourperemspace</key>
       <string>uni2005</string>
+      <key>foursubscript</key>
+      <string>uni2084</string>
       <key>foursuperior</key>
       <string>uni2074</string>
       <key>gcommaaccent</key>
@@ -1426,6 +1407,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0146</string>
       <key>ndotaccent</key>
       <string>uni1E45</string>
+      <key>ninesubscript</key>
+      <string>uni2089</string>
+      <key>ninesuperscript</key>
+      <string>uni2079</string>
       <key>notequal-slash</key>
       <string>notequalslash</string>
       <key>ocircumflexacute</key>
@@ -1454,6 +1439,8 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EDF</string>
       <key>ohorntilde</key>
       <string>uni1EE1</string>
+      <key>onesubscript</key>
+      <string>uni2081</string>
       <key>onesuperior</key>
       <string>uni00B9</string>
       <key>rcommaaccent</key>
@@ -1472,8 +1459,16 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni0219</string>
       <key>sdotbelow</key>
       <string>uni1E63</string>
+      <key>sevensubscript</key>
+      <string>uni2087</string>
+      <key>sevensuperscript</key>
+      <string>uni2077</string>
       <key>sixperemspace</key>
       <string>uni2006</string>
+      <key>sixsubscript</key>
+      <string>uni2086</string>
+      <key>sixsuperscript</key>
+      <string>uni2076</string>
       <key>slashshortcomb</key>
       <string>uni0337</string>
       <key>slashshortcomb.case</key>
@@ -1494,8 +1489,12 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni2009</string>
       <key>threeperemspace</key>
       <string>uni2004</string>
+      <key>threesubscript</key>
+      <string>uni2083</string>
       <key>threesuperior</key>
       <string>uni00B3</string>
+      <key>twosubscript</key>
+      <string>uni2082</string>
       <key>twosuperior</key>
       <string>uni00B2</string>
       <key>udotbelow</key>
@@ -1526,6 +1525,10 @@ H฿/baht.tf H/rupeeIndian.tf H/won.tf H
       <string>uni1EF7</string>
       <key>ytilde</key>
       <string>uni1EF9</string>
+      <key>zerosubscript</key>
+      <string>uni2080</string>
+      <key>zerosuperscript</key>
+      <string>uni2070</string>
       <key>zerowidthspace</key>
       <string>uni200B</string>
     </dict>

--- a/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
+++ b/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
@@ -264889,9 +264889,13 @@ key = licenses;
 values = (
 {
 language = dflt;
-value = "Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives.";
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org";
 }
 );
+},
+{
+key = licenseURL;
+value = "https://openfontlicense.org";
 },
 {
 key = manufacturers;
@@ -265414,6 +265418,6 @@ value = "1.5";
 };
 };
 };
-versionMajor = 2;
-versionMinor = 0;
+versionMajor = 3;
+versionMinor = 7;
 }


### PR DESCRIPTION
This commit was creating automatically using the GitHub workflow.

In https://github.com/googlefonts/googlesans-flex/pull/1194, we updated requirements for getting fontc compilation going, which updated glyphsLib. It generates UFO sources a bit differently (and arguably more correctly), so we want to update the UFO sources to be in sync with the Glyphs.app sources again and avoid rogue changes in future imports.

We may not want to keep every change (see the version number changes, that's probably wrong), but then we probably want to update the Glyphs.app sources to be more correct.