### PR TITLE
Remove hardcoded Axis Mapping parameter

### DIFF
--- a/scripts/glyphs_to_ds.py
+++ b/scripts/glyphs_to_ds.py
@@ -42,18 +42,6 @@ def glyphs_to_designspace(glyphs_source: Path, designspace_target: Path) -> None
         for layer in glyph.layers:
             layer.background.components = []
 
-    # Add axis mappings based on min and max of each axis.
-    # Motivation: required for glyphsLib to set axes bounds correctly.
-    #             https://github.com/googlefonts/glyphsLib/issues/942
-    font.customParameters["Axis Mappings"] = {  # type: ignore
-        "opsz": {"6": 6, "144": 144},
-        "wdth": {"25": 25, "151": 151},
-        "wght": {"1": 1, "1000": 1000},
-        "slnt": {"0": 0, "-10": -10},
-        "ROND": {"0": 0, "100": 100},
-        "GRAD": {"0": 0, "100": 100},
-    }
-
     # Give every brace layer a name.
     # Motivation: required for glyphsLib to export unnamed brace layers.
     #             https://github.com/googlefonts/glyphsLib/issues/952


### PR DESCRIPTION
Addresses Octavio's issue, raised [here](https://chat.google.com/room/AAAAgistbQI/fKa0dMXlXDU/fKa0dMXlXDU?cls=10)

This lets glyphsLib infer the axes from masters instead of telling it explicitly